### PR TITLE
Explicitly cleanup resource savers + clangtidy.

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -87,7 +87,7 @@ ClassDB::ClassInfo::ClassInfo() {
     exposed = false;
 }
 
-ClassDB::ClassInfo::~ClassInfo() {}
+ClassDB::ClassInfo::~ClassInfo() = default;
 
 bool ClassDB::is_parent_class(const StringName &p_class, const StringName &p_inherits) {
 

--- a/core/compressed_translation.cpp
+++ b/core/compressed_translation.cpp
@@ -289,4 +289,4 @@ void PHashTranslation::_bind_methods() {
     MethodBinder::bind_method(D_METHOD("generate", {"from"}), &PHashTranslation::generate);
 }
 
-PHashTranslation::PHashTranslation() {}
+PHashTranslation::PHashTranslation() = default;

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -103,7 +103,7 @@ Ref<X509Certificate> Crypto::generate_self_signed_certificate(Ref<CryptoKey> p_k
     ERR_FAIL_V_CMSG(Ref<X509Certificate>(), "generate_self_signed_certificate is not available when mbedtls module is disabled.")
 }
 
-Crypto::Crypto() {}
+Crypto::Crypto() = default;
 
 /// Resource loader/saver
 
@@ -157,7 +157,7 @@ Error ResourceFormatSaverCrypto::save(const String &p_path, const RES &p_resourc
     } else {
         ERR_FAIL_V(ERR_INVALID_PARAMETER)
     }
-	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Crypto resource to file '" + p_path + "'.")
+    ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Crypto resource to file '" + p_path + "'.")
     return OK;
 }
 

--- a/core/global_constants.cpp
+++ b/core/global_constants.cpp
@@ -46,7 +46,7 @@ struct _GlobalConstant {
     const char *name;
     int value;
 
-    _GlobalConstant() {}
+    _GlobalConstant() = default;
 
 #ifdef DEBUG_METHODS_ENABLED
     _GlobalConstant(StringName p_enum_name, const char *p_name, int p_value) :

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2194,7 +2194,7 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
 
     int pixel_size = get_format_pixel_size(format);
 
-    Ref<Image> msk = p_mask;
+    const Ref<Image> &msk(p_mask);
     msk->lock();
 
     for (int i = 0; i < dest_rect.size.y; i++) {
@@ -2204,7 +2204,7 @@ void Image::blit_rect_mask(const Ref<Image> &p_src, const Ref<Image> &p_mask, co
             int src_x = clipped_src_rect.position.x + j;
             int src_y = clipped_src_rect.position.y + i;
 
-            if (msk->get_pixel(src_x, src_y).a != 0) {
+            if (msk->get_pixel(src_x, src_y).a != 0.0f) {
 
                 int dst_x = dest_rect.position.x + j;
                 int dst_y = dest_rect.position.y + i;

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -281,3 +281,8 @@ void ResourceSaver::remove_custom_savers() {
         remove_resource_format_saver(custom_savers[i]);
     }
 }
+
+void ResourceSaver::finalize()
+{
+    saver.clear();
+}

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -81,4 +81,5 @@ public:
     static void remove_custom_resource_format_saver(const String& script_path);
     static void add_custom_savers();
     static void remove_custom_savers();
+    static void finalize();
 };

--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -223,9 +223,9 @@ bool AABB::intersects_plane(const Plane &p_plane) const {
     bool over = false;
     bool under = false;
 
-    for (int i = 0; i < 8; i++) {
+    for (auto point : points) {
 
-        if (p_plane.distance_to(points[i]) > 0)
+        if (p_plane.distance_to(point) > 0)
             over = true;
         else
             under = true;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -326,7 +326,7 @@ void unregister_core_types() {
         memdelete(ip);
 
     ResourceLoader::finalize();
-
+    ResourceSaver::finalize();
     ClassDB::cleanup_defaults();
     ObjectDB::cleanup();
 
@@ -341,7 +341,7 @@ void unregister_core_types() {
     if (_global_mutex) {
         memdelete(_global_mutex);
         _global_mutex = nullptr; //still needed at a few places
-    };
+    }
 
     MemoryPool::cleanup();
 }

--- a/core/string_name.cpp
+++ b/core/string_name.cpp
@@ -150,6 +150,8 @@ void StringName::cleanup() {
     }
 
     memdelete(lock);
+    lock = nullptr;
+    configured = false;
 }
 
 void StringName::unref() {

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -112,34 +112,34 @@ Error AudioDriverALSA::init_device() {
 
     // set buffer size from project settings
     status = snd_pcm_hw_params_set_buffer_size_near(pcm_handle, hwparams, &buffer_size);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     status = snd_pcm_hw_params_set_period_size_near(pcm_handle, hwparams, &period_size, nullptr);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     print_verbose("Audio buffer frames: " + itos(period_size) + " calculated latency: " + itos(period_size * 1000 / mix_rate) + "ms");
 
     status = snd_pcm_hw_params_set_periods_near(pcm_handle, hwparams, &periods, nullptr);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     status = snd_pcm_hw_params(pcm_handle, hwparams);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     //snd_pcm_hw_params_free(&hwparams);
 
     snd_pcm_sw_params_alloca(&swparams);
 
     status = snd_pcm_sw_params_current(pcm_handle, swparams);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     status = snd_pcm_sw_params_set_avail_min(pcm_handle, swparams, period_size);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     status = snd_pcm_sw_params_set_start_threshold(pcm_handle, swparams, 1);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     status = snd_pcm_sw_params(pcm_handle, swparams);
-    CHECK_FAIL(status < 0);
+    CHECK_FAIL(status < 0)
 
     samples_in.resize(period_size * channels);
     samples_out.resize(period_size * channels);
@@ -343,10 +343,7 @@ AudioDriverALSA::AudioDriverALSA() :
         new_device("Default") {
 }
 
-AudioDriverALSA::~AudioDriverALSA()
-{
-
-}
+AudioDriverALSA::~AudioDriverALSA() = default;
 
 
 #endif

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -150,7 +150,7 @@ public:
 
     void draw_window_margins(int *black_margin, RID *black_image) override;
 
-	RasterizerCanvasGLES3() {}
+    RasterizerCanvasGLES3() = default;
 };
 
 #endif // RASTERIZERCANVASGLES3_H

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5365,7 +5365,7 @@ void RasterizerSceneGLES3::iteration() {
 void RasterizerSceneGLES3::finalize() {
 }
 
-RasterizerSceneGLES3::RasterizerSceneGLES3() {}
+RasterizerSceneGLES3::RasterizerSceneGLES3() = default;
 
 RasterizerSceneGLES3::~RasterizerSceneGLES3() {
 

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -267,7 +267,6 @@ IP *IP_Unix::_create_unix() {
     return memnew(IP_Unix);
 }
 
-IP_Unix::IP_Unix() {
-}
+IP_Unix::IP_Unix() = default;
 
 #endif

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -188,5 +188,4 @@ void MultiNodeEdit::set_property_field(const StringName &p_property, const Varia
     _set_impl(p_property, p_value, p_field);
 }
 
-MultiNodeEdit::MultiNodeEdit() {
-}
+MultiNodeEdit::MultiNodeEdit() = default;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -128,7 +128,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
             stop->set_icon(get_icon("Stop", "EditorIcons"));
 
             onion_toggle->set_icon(get_icon("Onion", "EditorIcons"));
-			onion_skinning->set_icon(get_icon("GuiTabMenu", "EditorIcons"));
+            onion_skinning->set_icon(get_icon("GuiTabMenu", "EditorIcons"));
 
             pin->set_icon(get_icon("Pin", "EditorIcons"));
 
@@ -742,8 +742,8 @@ void AnimationPlayerEditor::_dialog_action(String p_file) {
             ERR_FAIL_COND(!player)
 
             Ref<Resource> res = ResourceLoader::load(p_file, "Animation");
-			ERR_FAIL_COND_MSG(not res, "Cannot load Animation from file '" + p_file + "'.")
-			ERR_FAIL_COND_MSG(!res->is_class("Animation"), "Loaded resource from file '" + p_file + "' is not Animation.")
+            ERR_FAIL_COND_MSG(not res, "Cannot load Animation from file '" + p_file + "'.")
+            ERR_FAIL_COND_MSG(!res->is_class("Animation"), "Loaded resource from file '" + p_file + "' is not Animation.")
             if (StringUtils::find_last(p_file,"/") != -1) {
 
                 p_file = StringUtils::substr(p_file,StringUtils::find_last(p_file,"/") + 1, p_file.length());
@@ -1864,5 +1864,4 @@ AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin(EditorNode *p_node) {
     editor->add_bottom_panel_item(TTR("Animation"), anim_editor);
 }
 
-AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {
-}
+AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() = default;

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -2189,5 +2189,4 @@ TileMapEditorPlugin::TileMapEditorPlugin(EditorNode *p_node) {
     tile_map_editor->hide();
 }
 
-TileMapEditorPlugin::~TileMapEditorPlugin() {
-}
+TileMapEditorPlugin::~TileMapEditorPlugin() = default;

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -39,70 +39,70 @@
 
 class BackgroundProgress : public HBoxContainer {
 
-	GDCLASS(BackgroundProgress,HBoxContainer)
+    GDCLASS(BackgroundProgress,HBoxContainer)
 
-	_THREAD_SAFE_CLASS_
+    _THREAD_SAFE_CLASS_
 
-	struct Task {
+    struct Task {
 
-		HBoxContainer *hb;
-		ProgressBar *progress;
-	};
+        HBoxContainer *hb;
+        ProgressBar *progress;
+    };
 
-	Map<String, Task> tasks;
-	Map<String, int> updates;
-	void _update();
+    Map<String, Task> tasks;
+    Map<String, int> updates;
+    void _update();
 
 protected:
-	void _add_task(const String &p_task, const String &p_label, int p_steps);
-	void _task_step(const String &p_task, int p_step = -1);
-	void _end_task(const String &p_task);
+    void _add_task(const String &p_task, const String &p_label, int p_steps);
+    void _task_step(const String &p_task, int p_step = -1);
+    void _end_task(const String &p_task);
 
-	static void _bind_methods();
+    static void _bind_methods();
 
 public:
-	void add_task(const String &p_task, const String &p_label, int p_steps);
-	void task_step(const String &p_task, int p_step = -1);
-	void end_task(const String &p_task);
+    void add_task(const String &p_task, const String &p_label, int p_steps);
+    void task_step(const String &p_task, int p_step = -1);
+    void end_task(const String &p_task);
 
-	BackgroundProgress() {}
+    BackgroundProgress() = default;
 };
 
 class ProgressDialog : public Popup {
 
-	GDCLASS(ProgressDialog,Popup)
+    GDCLASS(ProgressDialog,Popup)
 
     struct Task {
 
-		String task;
-		VBoxContainer *vb;
-		ProgressBar *progress;
-		Label *state;
-	};
-	HBoxContainer *cancel_hb;
-	Button *cancel;
+        String task;
+        VBoxContainer *vb;
+        ProgressBar *progress;
+        Label *state;
+    };
+    HBoxContainer *cancel_hb;
+    Button *cancel;
 
-	Map<String, Task> tasks;
-	VBoxContainer *main;
-	uint64_t last_progress_tick;
+    Map<String, Task> tasks;
+    VBoxContainer *main;
+    uint64_t last_progress_tick;
 
-	static ProgressDialog *singleton;
-	void _popup();
+    static ProgressDialog *singleton;
+    void _popup();
 
-	void _cancel_pressed();
-	bool cancelled;
+    void _cancel_pressed();
+    bool cancelled;
 
 protected:
-	void _notification(int p_what);
-	static void _bind_methods();
+    void _notification(int p_what);
+    static void _bind_methods();
 
 public:
-	static ProgressDialog *get_singleton() { return singleton; }
-	void add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
-	bool task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_redraw = true);
-	void end_task(const String &p_task);
+    static ProgressDialog *get_singleton() { return singleton; }
+    void add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
+    bool task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_redraw = true);
+    void end_task(const String &p_task);
 
-	ProgressDialog();
+    ProgressDialog();
 };
 
 #endif // PROGRESS_DIALOG_H

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1332,5 +1332,4 @@ ProjectExportDialog::ProjectExportDialog() {
     _update_export_all();
 }
 
-ProjectExportDialog::~ProjectExportDialog() {
-}
+ProjectExportDialog::~ProjectExportDialog() = default;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -93,7 +93,7 @@ void SceneTreeDock::_input(const Ref<InputEvent>& p_event) {
     }
 }
 
-void SceneTreeDock::_unhandled_key_input(Ref<InputEvent> p_event) {
+void SceneTreeDock::_unhandled_key_input(const Ref<InputEvent>& p_event) {
 
     if (get_viewport()->get_modal_stack_top())
         return; //ignore because of modal window
@@ -936,7 +936,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
                     bool placeholder = node->get_scene_instance_load_placeholder();
                     // Fire confirmation dialog when children are editable.
                     if (editable && !placeholder) {
-                        placeholder_editable_instance_remove_dialog->set_text(TTR("Enabling \"Load As Placeholder\" will disable \"Editable Children\" and cause all properties of the node to be reverted to their default."));
+                        placeholder_editable_instance_remove_dialog->set_text(TTR(R"(Enabling "Load As Placeholder" will disable "Editable Children" and cause all properties of the node to be reverted to their default.)"));
                         placeholder_editable_instance_remove_dialog->popup_centered_minsize();
                         break;
                     }
@@ -1660,7 +1660,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
             NodePath old_new_name = path_renames[ni].second;
             NodePath new_path;
 
-            Vector<StringName> unfixed_new_names = old_new_name.get_names();
+            const Vector<StringName>& unfixed_new_names = old_new_name.get_names();
             Vector<StringName> fixed_new_names;
 
             // Get last name and replace with fixed new name.
@@ -1780,7 +1780,7 @@ void SceneTreeDock::_set_collapsed_recursive(TreeItem *p_item, bool p_collapsed)
     }
 }
 
-void SceneTreeDock::_script_created(Ref<Script> p_script) {
+void SceneTreeDock::_script_created(const Ref<Script>& p_script) {
 
     List<Node *> selected = editor_selection->get_selected_node_list();
 

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -178,7 +178,7 @@ class SceneTreeDock : public VBoxContainer {
 
     void _node_selected();
     void _node_renamed();
-    void _script_created(Ref<Script> p_script);
+    void _script_created(const Ref<Script>& p_script);
     void _script_creation_closed();
 
     void _delete_confirm();
@@ -192,7 +192,7 @@ class SceneTreeDock : public VBoxContainer {
 
     void _nodes_drag_begin();
     void _input(const Ref<InputEvent>& p_event);
-    void _unhandled_key_input(Ref<InputEvent> p_event);
+    void _unhandled_key_input(const Ref<InputEvent>& p_event);
 
     void _import_subscene();
 

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1296,5 +1296,4 @@ SceneTreeDialog::SceneTreeDialog() {
     vbc->add_child(tree);
 }
 
-SceneTreeDialog::~SceneTreeDialog() {
-}
+SceneTreeDialog::~SceneTreeDialog() = default;

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -118,8 +118,7 @@ public:
         _change_notify();
     }
 
-    ScriptEditorDebuggerVariables() {
-    }
+    ScriptEditorDebuggerVariables() = default;
 };
 IMPL_GDCLASS(ScriptEditorDebuggerVariables)
 
@@ -1621,9 +1620,9 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 
     VARIANT_ARGPTRS
 
-    for (int i = 0; i < VARIANT_ARG_MAX; i++) {
+    for (const Variant *i : argptr) {
         //no pointers, sorry
-        if (argptr[i] && (argptr[i]->get_type() == VariantType::OBJECT || argptr[i]->get_type() == VariantType::_RID))
+        if (i && (i->get_type() == VariantType::OBJECT || i->get_type() == VariantType::_RID))
             return;
     }
 
@@ -1636,9 +1635,9 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
         msg.push_back("live_node_call");
         msg.push_back(pathid);
         msg.push_back(p_name);
-        for (int i = 0; i < VARIANT_ARG_MAX; i++) {
+        for (const Variant *i : argptr) {
             //no pointers, sorry
-            msg.push_back(*argptr[i]);
+            msg.push_back(*i);
         }
         ppeer->put_var(msg);
 
@@ -1656,9 +1655,9 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
         msg.push_back("live_res_call");
         msg.push_back(pathid);
         msg.push_back(p_name);
-        for (int i = 0; i < VARIANT_ARG_MAX; i++) {
+        for (const Variant *i : argptr) {
             //no pointers, sorry
-            msg.push_back(*argptr[i]);
+            msg.push_back(*i);
         }
         ppeer->put_var(msg);
 

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1508,8 +1508,7 @@ void CameraSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 
 //////
 
-MeshInstanceSpatialGizmoPlugin::MeshInstanceSpatialGizmoPlugin() {
-}
+MeshInstanceSpatialGizmoPlugin::MeshInstanceSpatialGizmoPlugin() = default;
 
 bool MeshInstanceSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
     return Object::cast_to<MeshInstance>(p_spatial) != nullptr && Object::cast_to<SoftBody>(p_spatial) == nullptr;
@@ -1545,8 +1544,7 @@ void MeshInstanceSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 }
 
 /////
-Sprite3DSpatialGizmoPlugin::Sprite3DSpatialGizmoPlugin() {
-}
+Sprite3DSpatialGizmoPlugin::Sprite3DSpatialGizmoPlugin() = default;
 
 bool Sprite3DSpatialGizmoPlugin::has_gizmo(Spatial *p_spatial) {
     return Object::cast_to<Sprite3D>(p_spatial) != nullptr;

--- a/modules/assimp/editor_scene_importer_assimp.cpp
+++ b/modules/assimp/editor_scene_importer_assimp.cpp
@@ -334,7 +334,7 @@ Spatial *EditorSceneImporterAssimp::_generate_scene(const String &p_path, aiScen
     return state.root;
 }
 
-void EditorSceneImporterAssimp::_insert_animation_track(ImportState &scene, const aiAnimation *assimp_anim, int p_track, int p_bake_fps, Ref<Animation> animation, float ticks_per_second, Skeleton *p_skeleton, const NodePath &p_path, const String &p_name) {
+void EditorSceneImporterAssimp::_insert_animation_track(ImportState &scene, const aiAnimation *assimp_anim, int p_track, int p_bake_fps, const Ref<Animation>& animation, float ticks_per_second, Skeleton *p_skeleton, const NodePath &p_path, const String &p_name) {
 
     const aiNodeAnim *assimp_track = assimp_anim->mChannels[p_track];
     //make transform track

--- a/modules/assimp/editor_scene_importer_assimp.h
+++ b/modules/assimp/editor_scene_importer_assimp.h
@@ -115,7 +115,7 @@ private:
     void _generate_node(ImportState &state, Skeleton *skeleton, const aiNode *assimp_node, Node *parent_node);
     // runs after _generate_node as it must then use pre-created godot skeleton.
     void generate_mesh_phase_from_skeletal_mesh(ImportState &state);
-    void _insert_animation_track(ImportState &scene, const aiAnimation *assimp_anim, int p_track, int p_bake_fps, Ref<Animation> animation, float ticks_per_second, Skeleton *p_skeleton, const NodePath &p_path, const String &p_name);
+    void _insert_animation_track(ImportState &scene, const aiAnimation *assimp_anim, int p_track, int p_bake_fps, const Ref<Animation>& animation, float ticks_per_second, Skeleton *p_skeleton, const NodePath &p_path, const String &p_name);
 
     void _import_animation(ImportState &state, int p_animation_index, int p_bake_fps);
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -688,8 +688,7 @@ CSGBrush *CSGCombiner::_build_brush() {
     return nullptr; //does not build anything
 }
 
-CSGCombiner::CSGCombiner() {
-}
+CSGCombiner::CSGCombiner() = default;
 
 /////////////////////
 

--- a/platform/osx/export/export.cpp
+++ b/platform/osx/export/export.cpp
@@ -244,12 +244,12 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
         { "is32", "s8mk", false, 16 } //16x16 24-bit RLE + 8-bit uncompressed mask
     };
 
-    for (uint64_t i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
-        Ref<Image> copy = p_icon; // does this make sense? doesn't this just increase the reference count instead of making a copy? Do we even need a copy?
+    for (const MacOSIconInfo & icon_info : icon_infos) {
+        const Ref<Image> &copy(p_icon);
         copy->convert(Image::FORMAT_RGBA8);
-        copy->resize(icon_infos[i].size, icon_infos[i].size);
+        copy->resize(icon_info.size, icon_info.size);
 
-        if (icon_infos[i].is_png) {
+        if (icon_info.is_png) {
             // Encode PNG icon.
             it->create_from_image(copy);
             String path = PathUtils::plus_file(EditorSettings::get_singleton()->get_cache_dir(),"icon.png");
@@ -269,7 +269,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
             memdelete(f);
             len += 8;
             len = BSWAP32(len);
-            memcpy(&data.write[ofs], icon_infos[i].name, 4);
+            memcpy(&data.write[ofs], icon_info.name, 4);
             encode_uint32(len, &data.write[ofs + 4]);
 
             // Clean up generated file.
@@ -283,13 +283,13 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
                 int ofs = data.size();
                 data.resize(data.size() + 8);
 
-                _rgba8_to_packbits_encode(0, icon_infos[i].size, src_data, data); // encode R
-                _rgba8_to_packbits_encode(1, icon_infos[i].size, src_data, data); // encode G
-                _rgba8_to_packbits_encode(2, icon_infos[i].size, src_data, data); // encode B
+                _rgba8_to_packbits_encode(0, icon_info.size, src_data, data); // encode R
+                _rgba8_to_packbits_encode(1, icon_info.size, src_data, data); // encode G
+                _rgba8_to_packbits_encode(2, icon_info.size, src_data, data); // encode B
 
                 int len = data.size() - ofs;
                 len = BSWAP32(len);
-                memcpy(&data.write[ofs], icon_infos[i].name, 4);
+                memcpy(&data.write[ofs], icon_info.name, 4);
                 encode_uint32(len, &data.write[ofs + 4]);
             }
 
@@ -304,7 +304,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
                 }
                 len += 8;
                 len = BSWAP32(len);
-                memcpy(&data.write[ofs], icon_infos[i].mask_name, 4);
+                memcpy(&data.write[ofs], icon_info.mask_name, 4);
                 encode_uint32(len, &data.write[ofs + 4]);
             }
         }

--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -3634,9 +3634,7 @@ ShaderLanguage::Node *ShaderLanguage::_reduce_expression(BlockNode *p_block, Sha
                 ConstantNode *cn = static_cast<ConstantNode *>(op->arguments[i]);
 
                 if (get_scalar_type(cn->datatype) == base) {
-                    for (size_t j = 0; j < cn->values.size(); j++) {
-                        values.push_back(cn->values[j]);
-                    }
+                    values.push_back(cn->values);
                 } else if (get_scalar_type(cn->datatype) == cn->datatype) {
 
                     ConstantNode::Value v;

--- a/servers/visual/visual_server_light_baker.cpp
+++ b/servers/visual/visual_server_light_baker.cpp
@@ -30,5 +30,4 @@
 
 #include "visual_server_light_baker.h"
 
-VisualServerLightBaker::VisualServerLightBaker() {
-}
+VisualServerLightBaker::VisualServerLightBaker() = default;

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -201,8 +201,8 @@ public:
 
 	bool free(RID p_rid);
 
-	VisualServerViewport() {}
-	virtual ~VisualServerViewport() {}
+	VisualServerViewport() = default;
+	virtual ~VisualServerViewport() = default;
 };
 
 #endif // VISUALSERVERVIEWPORT_H


### PR DESCRIPTION
prevents crash when static ResourceFormatSaver deque entries are freed.